### PR TITLE
Add CI, MIT license, entry-point plugins, and configurable tag prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.3.1
         with:
           enable-cache: true
       - name: Run the test suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Run the test suite
+        run: uv run pytest

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Steve Holden
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ must be available.
 
 ## License
 
-<!-- TODO: choose a license and add a LICENSE file. -->
+MIT — see [LICENSE](LICENSE).
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ release. Because it builds the current version as-is, `--snapshot` takes no
 bump argument.
 
 > Local versions install and resolve fine from a file, URL, or private index,
-> but public indexes such as PyPI **reject** them on upload — which is the point:
+> but public indexes such as PyPI **reject** them on upload:
 > a snapshot is a throwaway build, not something to publish.
 
 ### `v_next` — predict a version
@@ -157,13 +157,17 @@ overwriting it.
 - `RELEASE_NOCHECKS` — set to any non-empty value to skip the pre-release
   checks (clean working tree and plugin vetting). Use with care.
 
-## Experimental: plugins
+## Plugins
 
-Any importable module named `release_<something>` that exposes a
-`vet(cached_file)` function can veto a release by returning a message when it
-objects to a file's path or contents (for example, to block a debugger stub
-from being released). This mechanism is **experimental and incomplete** — treat
-it as subject to change.
+`release` can veto a release based on your files. A plugin is a
+`vet(cached_file)` callable that returns a message to block the release (or
+`None` to allow it), registered under the `release.plugins`
+[entry-point group](https://packaging.python.org/en/latest/specifications/entry-points/).
+Discovery reads the environment `release` is installed in, so a plugin must be
+installed alongside the tool — **none are enabled by default**.
+
+See [`examples/plugins/`](examples/plugins/) for a working example (blocking
+Wing IDE debugger stubs) and instructions for enabling or adapting it.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -148,14 +148,18 @@ $ v_next minor alpha
 
 ## Tags
 
-Releases are tagged `r<version>` (for example `r1.4.0` or `r0.6.0rc1`). Tagging
-is non-destructive: if the tag already exists, `release` refuses rather than
+Releases are tagged `r<version>` (for example `r1.4.0` or `r0.6.0rc1`). The `r`
+prefix can be changed with the `RELEASE_TAG_PREFIX` environment variable — set
+it to `v` for `v1.4.0`, or to an empty string for a bare `1.4.0`. Tagging is
+non-destructive: if the tag already exists, `release` refuses rather than
 overwriting it.
 
 ## Environment variables
 
 - `RELEASE_NOCHECKS` — set to any non-empty value to skip the pre-release
   checks (clean working tree and plugin vetting). Use with care.
+- `RELEASE_TAG_PREFIX` — the prefix for release tags (default `r`, giving
+  `r1.4.0`).
 
 ## Plugins
 

--- a/examples/plugins/README.md
+++ b/examples/plugins/README.md
@@ -1,0 +1,43 @@
+# Example release plugins
+
+A **plugin** for [`release`](../../README.md) is a callable that vets a single
+file and either returns a message (to veto the release) or `None` (to allow it):
+
+```python
+def no_debug_file(cached_file):
+    if cached_file.path.endswith("/wingdbstub.py"):
+        return "is a Wing debugger stub"
+```
+
+`cached_file` exposes `.path` and `.read_text()`. Before cutting a release,
+`release` runs every plugin against every file in the tree; if any returns a
+message, the release is refused (exit code 3).
+
+Plugins are discovered through the `release.plugins`
+[entry-point group](https://packaging.python.org/en/latest/specifications/entry-points/),
+so a plugin must be **installed into the same environment as `release`** — nothing
+loads automatically.
+
+## What's here
+
+`release_wing_plugins` blocks [Wing IDE](https://wingware.com/) debugger stubs —
+`wingdbstub.py` files, and `.py`/`.pyw` files that still `import wingdbstub` —
+from being released. It is **specific to Wing**; treat it as a template.
+
+## Enabling it
+
+Install the plugin package alongside the `release` tool so its entry points are
+visible to it:
+
+```bash
+uv tool install release --with /path/to/release/examples/plugins
+```
+
+`release` will then print `Plugins: no-wingdbstub-file, no-wingdbstub-import` on
+each run and refuse to release a tree that still contains Wing debugger stubs.
+
+## Writing your own
+
+Copy this directory, rewrite the `vet` functions, and update the
+`[project.entry-points."release.plugins"]` table in `pyproject.toml` to point at
+them. Then install it the same way.

--- a/examples/plugins/pyproject.toml
+++ b/examples/plugins/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "release-wing-plugins"
+version = "0.1.0"
+description = "Example `release` plugins that keep Wing IDE debugger stubs out of a release."
+requires-python = ">=3.12"
+
+[project.entry-points."release.plugins"]
+no-wingdbstub-file = "release_wing_plugins:no_debug_file"
+no-wingdbstub-import = "release_wing_plugins:no_debug_import"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/examples/plugins/release_wing_plugins/__init__.py
+++ b/examples/plugins/release_wing_plugins/__init__.py
@@ -1,0 +1,24 @@
+"""Example ``release`` plugins: keep Wing IDE debugger stubs out of a release.
+
+A plugin is a *vet* callable. Given a file -- an object with ``.path`` and
+``.read_text()`` -- it returns a message to veto the release, or ``None`` to
+allow it. These functions are registered under the ``release.plugins``
+entry-point group in this package's pyproject.toml.
+
+They are specific to `Wing IDE <https://wingware.com/>`_; copy this directory
+and adapt them for your own environment.
+"""
+
+def no_debug_file(cached_file):
+    """Veto a bare ``wingdbstub.py`` debugger stub anywhere in the tree."""
+    if cached_file.path == "wingdbstub.py" or cached_file.path.endswith("/wingdbstub.py"):
+        return "is a Wing debugger stub"
+
+
+_GUILTY = "import" + " wingdbstub"
+
+
+def no_debug_import(cached_file):
+    """Veto any .py/.pyw file that still imports the Wing debugger."""
+    if cached_file.path.endswith((".py", ".pyw")) and _GUILTY in cached_file.read_text():
+        return "still imports the Wing debugger (wingdbstub)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "release"
 version = "0.6.0"
 description = "Release control process"
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.12"
 dependencies = [
     "packaging>=26.2",

--- a/src/release/__init__.py
+++ b/src/release/__init__.py
@@ -1,9 +1,9 @@
 import argparse
-import importlib
 import os
 import sys
 import subprocess
 from glob import glob
+from importlib.metadata import entry_points
 from .version import __version__
 from .setver import (
     read_version,
@@ -14,7 +14,7 @@ from .setver import (
     RELEASE_NOCHECKS,
 )
 
-import pkgutil
+PLUGIN_GROUP = "release.plugins"
 
 
 def run_or_die(cmd, what):
@@ -36,14 +36,17 @@ class CachedFile:
 
 
 def load_plugins():
-    plugins = {
-        name: importlib.import_module(name)
-        for finder, name, ispkg in pkgutil.iter_modules()
-        if name.startswith("release_")
-    }
+    """Return the vet callables registered under the ``release.plugins`` group.
+
+    Each entry point loads to a ``vet(cached_file)`` callable that returns a
+    message to veto the release (or None to allow it). Discovery reads the
+    environment ``release`` is installed in, so a plugin must be installed
+    alongside the tool -- none ship enabled. See examples/plugins/.
+    """
+    plugins = [(ep.name, ep.load()) for ep in entry_points(group=PLUGIN_GROUP)]
     if plugins:
-        print("Plugins:", ", ".join(name for name in plugins))
-    return list(plugins.values())
+        print("Plugins:", ", ".join(name for name, _ in plugins))
+    return [vet for _, vet in plugins]
 
 
 def release(*args, dry_run=False, message=None, allow_dirty=False):
@@ -72,14 +75,17 @@ def release(*args, dry_run=False, message=None, allow_dirty=False):
 
     print(f"release {__version__} creating release {proj_name} {' '.join(args)}")
 
-    # Ensure no plugin blackballs the content of any file.
+    # Ensure no plugin blackballs the content of any file. Each file is read at
+    # most once (CachedFile), shared across plugins; directories are skipped.
     oopsies = False
     for source in glob("**/*", recursive=True):
-        for plugin in plugins:
-            m = plugin.vet(f := CachedFile(source))
-            if m:
+        if not os.path.isfile(source):
+            continue
+        cached = CachedFile(source)
+        for vet in plugins:
+            if m := vet(cached):
                 oopsies = True
-                print(f.path, m)
+                print(cached.path, m)
     if oopsies and not RELEASE_NOCHECKS:
         sys.exit(3)
 

--- a/src/release/__init__.py
+++ b/src/release/__init__.py
@@ -12,6 +12,7 @@ from .setver import (
     v_next_cli,
     BUMPS,
     RELEASE_NOCHECKS,
+    TAG_PREFIX,
 )
 
 PLUGIN_GROUP = "release.plugins"
@@ -58,7 +59,7 @@ def release(*args, dry_run=False, message=None, allow_dirty=False):
     # arguments and lets us preview and check the tag *before* mutating
     # anything and leaving a half-released tree behind.
     _, prospective = update_project_version(*args, dry_run=True)
-    tag = f"r{prospective}"
+    tag = f"{TAG_PREFIX}{prospective}"
     tag_exists = tag in subprocess.run(
         ["git", "tag", "--list", tag], capture_output=True
     ).stdout.decode("utf-8").split()

--- a/src/release/setver.py
+++ b/src/release/setver.py
@@ -8,6 +8,7 @@ from packaging.version import Version
 from .version import __version__
 
 RELEASE_NOCHECKS = os.environ.get("RELEASE_NOCHECKS", "") != ""
+TAG_PREFIX = os.environ.get("RELEASE_TAG_PREFIX", "r")
 
 BUMPS = "major, minor, patch, stable, alpha, beta, rc, post, dev".split(", ")
 

--- a/src/release_check_debug.py
+++ b/src/release_check_debug.py
@@ -1,6 +1,0 @@
-GUILTY_STRING = "import" + " wingdbstub"
-
-def vet(c_file):
-    if any(c_file.path.endswith(x) for x in (".py", ".pyw")):
-        if GUILTY_STRING in c_file.read_text():
-            return "still includes wingdbstub imports"

--- a/src/release_debug_file.py
+++ b/src/release_debug_file.py
@@ -1,3 +1,0 @@
-def vet(c_file):
-    if c_file.path == "wingdbstub.py" or c_file.path.endswith("/wingdbstub.py"):
-        return "is a debug file"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,59 @@
+"""Tests for entry-point plugin discovery and the vetting loop."""
+import pytest
+
+import release
+from release.setver import read_version
+
+
+class _FakeEntryPoint:
+    def __init__(self, name, fn):
+        self.name = name
+        self._fn = fn
+
+    def load(self):
+        return self._fn
+
+
+def test_load_plugins_returns_entry_point_callables(monkeypatch):
+    def veto(cached):
+        return "nope"
+
+    monkeypatch.setattr(
+        "release.entry_points",
+        lambda group: [_FakeEntryPoint("demo", veto)] if group == "release.plugins" else [],
+    )
+    plugins = release.load_plugins()
+    assert len(plugins) == 1
+    assert plugins[0](object()) == "nope"
+
+
+def test_load_plugins_is_empty_by_default(monkeypatch):
+    monkeypatch.setattr("release.entry_points", lambda group: [])
+    assert release.load_plugins() == []
+
+
+@pytest.mark.integration
+def test_release_is_blocked_by_a_vetoing_plugin(uv_project, monkeypatch):
+    def veto_readme(cached):
+        return "blocked" if cached.path.endswith("README.md") else None
+
+    monkeypatch.setattr("release.entry_points", lambda group: [_FakeEntryPoint("no-readme", veto_readme)])
+    monkeypatch.setattr("release.RELEASE_NOCHECKS", False)
+    with pytest.raises(SystemExit) as exc:
+        release.release("minor")
+    assert exc.value.code == 3
+    assert read_version()[1] == "0.1.0"          # not released
+
+
+@pytest.mark.integration
+def test_vet_loop_skips_directories(uv_project, monkeypatch):
+    # A plugin that reads *every* path must not choke on directories (src/ etc.);
+    # the loop only feeds it real files.
+    def read_everything(cached):
+        cached.read_text()
+        return None
+
+    monkeypatch.setattr("release.entry_points", lambda group: [_FakeEntryPoint("reader", read_everything)])
+    monkeypatch.setattr("release.RELEASE_NOCHECKS", False)
+    release.release("minor")
+    assert read_version()[1] == "0.2.0"          # completed and released

--- a/tests/test_release_flow.py
+++ b/tests/test_release_flow.py
@@ -37,6 +37,13 @@ def test_release_explicit_version_commits_and_tags(uv_project):
     assert _last_commit_subject() == "release commit"
 
 
+def test_release_honours_custom_tag_prefix(uv_project, monkeypatch):
+    monkeypatch.setattr("release.TAG_PREFIX", "v")
+    release("minor")
+    assert "v0.2.0" in git_tags()
+    assert "r0.2.0" not in git_tags()
+
+
 def test_release_bump_chain_commits_and_tags(uv_project):
     release("patch", "alpha")
     assert read_version()[1] == "0.1.1a1"


### PR DESCRIPTION
Four self-contained changes, one commit each.

## Changes

- **Add GitHub Actions CI** (`6a0eb64`) — runs the test suite on every push to `main` and on PRs (`checkout` → install `uv` → `uv run pytest`). The integration tests set their own git identity, so no extra config is needed.
- **Add MIT license** (`9b2e813`) — `LICENSE` file plus `license = "MIT"` / `license-files` in `pyproject.toml`. The package still builds cleanly with the field.
- **Discover plugins via entry points; ship Wing checks as an example** (`f943798`) — replaces the `pkgutil` scan (which never found plugins once the tool was installed) with `importlib.metadata` entry points in the `release.plugins` group, discovered from the environment `release` is installed in. **Nothing loads by default.** The Wing-IDE-specific checks move out of the package into `examples/plugins/` as an installable example the user opts into. The vet loop now reads each file once (shared `CachedFile`) and skips directories.
- **Make the release tag prefix configurable** (`55d192f`) — the tag prefix (`r` by default, e.g. `r0.4.1`) can now be set with the `RELEASE_TAG_PREFIX` environment variable: `RELEASE_TAG_PREFIX=v` → `v0.4.1`, empty string → bare `0.4.1`.

## Notes for reviewers

- The plugin change is the behavioural one worth a close look. Verified end-to-end: with `release` and the example plugin installed together, a `wingdbstub.py` blocks the release (exit 3, version unchanged) while a clean tree releases fine; with neither installed, no plugins run.
- CI only activates once this branch is on GitHub — the workflow itself is exercised by this PR.
- The two `src/release_*.py` files are **moved**, not deleted, into `examples/plugins/release_wing_plugins/`.

## Testing

- `uv run pytest` → **47 passed** (added: 4 plugin tests, 1 tag-prefix test).
- Manually verified `RELEASE_TAG_PREFIX=v` tagging, default `r` tagging, and the installed-plugin block/allow paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)